### PR TITLE
Introduce disable-file-truncate flag

### DIFF
--- a/cmd/sparsecat/main.go
+++ b/cmd/sparsecat/main.go
@@ -22,6 +22,7 @@ func main() {
 	formatName := flag.String("format", "rbd-diff-v1", "the wire format to use. Currently either rbd-diff-v1 or rbd-diff-v2")
 	receive := flag.Bool("r", false, "receive a file instead of transmitting")
 	disableSparseTarget := flag.Bool("disable-sparse-target", false, "disable sparse writing the target file")
+	disableFileTruncate := flag.Bool("disable-file-truncate", false, "disable truncating the target file, *only use this when you know what you are doing*")
 
 	flag.Parse()
 
@@ -64,6 +65,7 @@ func main() {
 	decoder := sparsecat.NewDecoder(inputFile)
 	decoder.Format = f
 	decoder.DisableSparseWriting = *disableSparseTarget
+	decoder.DisableFileTruncate = *disableFileTruncate
 
 	_, err := io.Copy(outputFile, decoder)
 	if err != nil {


### PR DESCRIPTION
Used for example when you write towards an empty disk device